### PR TITLE
nuxt.config.jsの設定を修正

### DIFF
--- a/assets/style/app.styl
+++ b/assets/style/app.styl
@@ -1,2 +1,0 @@
-// Import Vuetify styling
-@require '~vuetify/src/stylus/app.styl'

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,7 +1,7 @@
 import VuetifyLoaderPlugin from 'vuetify-loader/lib/plugin'
 
 export default {
-  mode: 'spa',
+  mode: 'universal',
 
   /*
    ** Headers of the page
@@ -53,6 +53,13 @@ export default {
         rel: 'stylesheet',
         href:
           'https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons'
+      },
+      // vuetifyのcssをCDNから取得
+      // 参考：https://V15.vuetifyjs.com/ja/getting-started/quick-start
+      {
+        rel: 'stylesheet',
+        href:
+          'https://cdn.jsdelivr.net/npm/vuetify@1.x/dist/vuetify.min.css'
       }
     ]
   },
@@ -61,11 +68,6 @@ export default {
    ** Customize the progress-bar color
    */
   loading: { color: '#fff' },
-
-  /*
-   ** Global CSS
-   */
-  css: ['~/assets/style/app.styl'],
 
   /*
    ** Plugins to load before mounting the App


### PR DESCRIPTION
resolve #3 #4

# 対応内容
- modeをuniversalに戻す
- vuetifyのcssをCDNから読み込む

## modeをuniversalに戻す
- OGPの確認サイトの結果がよくなかったため

### OGP確認サイトの結果
#### url
- https://developers.facebook.com/tools/debug/

#### 確認内容
- https://olivebodycare.healthcare/menu を確認
- `og:title` が `施術メニュー・料金` であるべきだが、 `整体・骨盤矯正の女性専門の治療院オリーヴボディケア` になっている

## vuetifyのcssをCDNから読み込む
- `yarn run generate` で生成されたhtmlにvuetifyのcssが記載されていた
- こちらを公式がCDN配信しているcssから取得するように修正
- 