### PR TITLE
fix：店名を円山町店から円山店に変更

### DIFF
--- a/components/index/Accesstop.vue
+++ b/components/index/Accesstop.vue
@@ -157,7 +157,7 @@
         <v-layout row wrap justify-center>
           <v-flex xs12 md12>
             <h3 class="my-3 accent--text text-xs-center">
-              札幌円山町店（9月6日オープン！）
+              札幌円山店（9月6日オープン！）
             </h3>
           </v-flex>
           <v-container grid-list-lg>
@@ -189,9 +189,9 @@
           </v-flex>
           <v-layout row wrap>
             <v-flex xs12 md6 class="mb-2 text-xs-center">
-              <nuxt-link to="/salon/maruyamacho">
+              <nuxt-link to="/salon/maruyama">
                 <v-btn color="primary" dark small>
-                  札幌円山町店詳しくはこちら
+                  札幌円山店詳しくはこちら
                 </v-btn>
               </nuxt-link>
             </v-flex>
@@ -203,7 +203,7 @@
                 color="light-green darken-2"
               >
                 <span class="font-weight-bold body-2"
-                  >札幌円山町店予約は今すぐこちら！</span
+                  >札幌円山店予約は今すぐこちら！</span
                 >
               </v-btn>
             </v-flex>

--- a/components/salon/Maruyamamessage.vue
+++ b/components/salon/Maruyamamessage.vue
@@ -47,7 +47,7 @@
 export default {
   data() {
     return {
-      name: '札幌円山町店店院長 國分 麻美（こくぶん あさみ）',
+      name: '札幌円山店院長 國分 麻美（こくぶん あさみ）',
       qualification: '柔道整復師',
       title: '私たちにお任せください！',
       message: '院長の國分麻美です。',

--- a/pages/reserve.vue
+++ b/pages/reserve.vue
@@ -65,7 +65,7 @@
         <v-flex xs12 md10>
           <v-card class="my-2" color="info">
             <h3 class="py-2 accent--text text-xs-center">
-              札幌円山町店（9月6日オープン！）
+              札幌円山店（9月6日オープン！）
             </h3>
             <v-layout row wrap justify-center>
               <v-flex xs12 md6 class="mb-2 text-xs-center">
@@ -76,7 +76,7 @@
                   color="light-green darken-2"
                 >
                   <span class="font-weight-bold body-2"
-                    >札幌円山町店予約は今すぐこちら！</span
+                    >札幌円山店予約は今すぐこちら！</span
                   >
                 </v-btn>
               </v-flex>

--- a/pages/salon/index.vue
+++ b/pages/salon/index.vue
@@ -83,14 +83,14 @@
         <v-flex xs12 md10>
           <v-card class="my-2" color="info">
             <h3 class="py-2 accent--text text-xs-center">
-              札幌円山町店（9月6日オープン！）
+              札幌円山店（9月6日オープン！）
             </h3>
             <v-layout row wrap>
               <v-flex xs12 md6 class="mb-2 text-xs-center">
-                <nuxt-link to="/salon/maruyamacho">
+                <nuxt-link to="/salon/maruyama">
                   <v-btn color="primary" dark>
                     <span class="font-weight-bold body-2"
-                      >札幌円山町店詳しくはこちら</span
+                      >札幌円山店詳しくはこちら</span
                     >
                   </v-btn>
                 </nuxt-link>
@@ -103,7 +103,7 @@
                   color="light-green darken-2"
                 >
                   <span class="font-weight-bold body-2"
-                    >札幌円山町店予約は今すぐこちら！</span
+                    >札幌円山店予約は今すぐこちら！</span
                   >
                 </v-btn>
               </v-flex>

--- a/pages/salon/maruyama.vue
+++ b/pages/salon/maruyama.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <pagetitle h1="札幌円山町店" />
+    <pagetitle h1="札幌円山店" />
     <div class="ml-2">
       <v-breadcrumbs :items="itemsB" divider=">"></v-breadcrumbs>
     </div>
@@ -79,11 +79,11 @@ export default {
   data() {
     return {
       meta: {
-        title: '札幌円山町店（札幌市中央区）',
+        title: '札幌円山店（札幌市中央区）',
         description:
           '整体・骨盤矯正の女性専門の治療院オリーヴボディケア。国家資格取得の女性スタッフによる本格施術が受けれます。お子様連れ歓迎。マッサージ、不妊、鍼もお任せ下さい！',
         type: 'website',
-        url: 'https://olivebodycare.healthcare/salon/maruyamacho',
+        url: 'https://olivebodycare.healthcare/salon/maruyama',
         image: 'https://olivebodycare.healthcare/assets/images/hed_1.jpg'
       },
       itemsB: [
@@ -98,9 +98,9 @@ export default {
           href: '/salon'
         },
         {
-          text: '札幌円山町店',
+          text: '札幌円山店',
           disabled: true,
-          href: '/salon/maruyamacho'
+          href: '/salon/maruyama'
         }
       ],
       items: [


### PR DESCRIPTION
### 対応内容
##変更点
札幌円山町店の名称を
札幌円山店に変更

・pagesフォルダのurlを
maruyamacho.vue
↓
maruyama.vue
に変更。

・各対応ページの名称変更

・リンクのurlを変更
