### PR TITLE
gtmの設定を追加

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -80,12 +80,11 @@ export default {
    */
   modules: [
     '@nuxtjs/pwa',
-    [
-      '@nuxtjs/google-analytics',
-      {
-        id: 'UA-146789861-1'
-      }
-    ],
+    ['@nuxtjs/google-tag-manager', {
+      id: 'GTM-P4S32NS',
+      pageTracking: true,
+      dev: process.env.NODE_ENV !== 'production'
+    }],
     '@nuxtjs/sitemap' // 一番後ろにする必要あり
   ],
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@nuxtjs/google-analytics": "^2.2.0",
+    "@nuxtjs/google-tag-manager": "^2.2.1",
     "@nuxtjs/pwa": "^2.6.0",
     "@nuxtjs/sitemap": "^1.3.0",
     "cross-env": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1362,12 +1362,10 @@
   resolved "https://registry.yarnpkg.com/@nuxtjs/eslint-config/-/eslint-config-0.0.1.tgz#3aeed1cc6a2e01331c7e6b56bfa7152ce8bb2d90"
   integrity sha512-Scz5oYNtVwePF1ebXcWPrFxBpNF5wAkYh8L++6f2ZdLyUb1mCOwzE2+oVZxS25hGCYUyecFEshbqeSwkC+ktqA==
 
-"@nuxtjs/google-analytics@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@nuxtjs/google-analytics/-/google-analytics-2.2.0.tgz#4b2072824961974109eb0bff6a95591fea92c6d9"
-  integrity sha512-Ds166zi7KAwc23gHOkKHovSdMEDJS55UJGkowT4IfVAOCE00l65J3fKI9t2P9+O5cdokXTadNiMLGZV5QM731Q==
-  dependencies:
-    vue-analytics "^5.16.2"
+"@nuxtjs/google-tag-manager@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/google-tag-manager/-/google-tag-manager-2.2.1.tgz#8029953dcc1d09a430fc5f961a48555017c875d0"
+  integrity sha512-1JpV8NRpdTd58FQiPyZUdFdYxfhrt6/a0UUQcoFMBbM3+pELho2RlOj52NE+OYY0IPR0D736ULBHXLhwv1CKdw==
 
 "@nuxtjs/icon@^2.6.0":
   version "2.6.0"
@@ -10423,11 +10421,6 @@ vm-browserify@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.0.tgz#bd76d6a23323e2ca8ffa12028dc04559c75f9019"
   integrity sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==
-
-vue-analytics@^5.16.2:
-  version "5.17.2"
-  resolved "https://registry.yarnpkg.com/vue-analytics/-/vue-analytics-5.17.2.tgz#5a43cbd907a8b5d2c27e3df5046245604fa8c83e"
-  integrity sha512-Vfbn5laOG8OVetrBNRfV64y/N5VVyw1PPC4LiowZFh58UOsfsGH8w+ZZn0pyMelSZmz9uxkgG5dNnce4bwJ6jg==
 
 vue-carousel@^0.18.0:
   version "0.18.0"


### PR DESCRIPTION
# 対応内容
- gtmの設定を追加
    - localでは、gtmのトラッキングをしないように修正
- gaの設定を削除
- `@nuxtjs/google-tag-manager` にあわせたgtm側の設定を実施
    - https://tagmanager.google.com/#/container/accounts/4702718211/containers/12818958/workspaces/1
    - 上記の設定は公開する必要がある
         - 現状、未公開。今やっても、おそらく大丈夫だが、念のため、保留