### PR TITLE
画像を遅延ロードする

### DIFF
--- a/components/Noticeslide.vue
+++ b/components/Noticeslide.vue
@@ -8,6 +8,7 @@
               v-for="(item, i) in itemsl"
               :key="i"
               :src="item.src"
+              lazy
             ></v-carousel-item>
           </v-carousel>
         </v-flex>
@@ -17,6 +18,7 @@
               v-for="(item, i) in itemsr"
               :key="i"
               :src="item.src"
+              lazy
             ></v-carousel-item>
           </v-carousel>
         </v-flex>

--- a/components/index/Headerslide.vue
+++ b/components/index/Headerslide.vue
@@ -7,6 +7,7 @@
             v-for="(item, i) in items"
             :key="i"
             :src="item.src"
+            lazy
           ></v-carousel-item>
         </v-carousel>
       </v-flex>


### PR DESCRIPTION
# 対応内容
- lazyの追加

# 期待効果
- seo対策のため、画像の遅延読み込みを可能にする
- v-imgでも同様のことができるが、一旦保留
    - 読込中の画像が必要なため
    - 以下のようなサイトから良さそうなものを使う？
         - https://ferret-plus.com/3878